### PR TITLE
handle `useLoadData` synchronous exception edge case

### DIFF
--- a/hooks/useLoadData/useLoadData.test.ts
+++ b/hooks/useLoadData/useLoadData.test.ts
@@ -370,4 +370,17 @@ describe('useLoadData', () => {
     expect(getFail).toHaveBeenCalledTimes(2);
     expect(mockRetry).toHaveBeenCalledTimes(0);
   });
+
+  it('should set isError to true if the fetch data function throws a non-promise exception', () => {
+    const {result} = renderHook(() => {
+      return useLoadData(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'immediate failure';
+      });
+    });
+
+    expect(result.current.isInProgress).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toBe('immediate failure');
+  });
 });


### PR DESCRIPTION
## Proposed changes

If the `fetchData` function passed to `useLoadData` throws a synchronous exception, then `useLoadData` should handle that and should return an initial state of "error".  Previously, `useLoadData` was not handling this scenario and a `fetchData` function that threw a synchronous exception would result in an unhandled exception.

For example, the following scenario currently throws an unhandled exception:

```TypeScript
useLoadData(() => {
  throw 'an error';
});
```

This PR allows the above scenario to be correctly handled such that `useLoadData` would simply return:

```TypeScript
{
  inProgress: false,
  result: undefined,
  isError: true,
  error: 'an error'
}
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
