### PR TITLE
fix: remove unneeded "source" key from package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,6 @@
   },
   "exports": {
     ".": {
-      "source": {
-        "types": "./index.ts",
-        "default": "./index.ts"
-      },
       "require": {
         "types": "./build/types/cjs/index.d.ts",
         "default": "./build/cjs/index.js"


### PR DESCRIPTION
## Proposed changes

The `"source"` field in the package.json `"exports"` is causing issues with some repos.  The purpose of this field is so that tools such as Jest and Storybook can resolve references to local packages without those packages needing to be built first.  However, in our entire repository there are currently no references to `@optum/react-hooks` which would need to be resolved locally, and the existence of this `"source"` custom condition is conflicting with other repos that also use `"source"`.

If we do at some point require this functionality (for example, if we turn this repository into a monorepo with multiple packages) then we should use a more unique name other than "source" to avoid conflicts with other repos that might be using "source" as a custom export condition.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

