### PR TITLE
fix: correctly check for promise in useLoadData

### DIFF
--- a/hooks/useLoadData/useLoadData.test.ts
+++ b/hooks/useLoadData/useLoadData.test.ts
@@ -442,4 +442,13 @@ describe('useLoadData', () => {
     expect(getSuccess).toHaveBeenCalledTimes(2);
     expect(getSuccess).toHaveBeenCalledWith('b');
   });
+
+  it('should treat a thenable object as a Promise', async () => {
+    const getThenableSuccess = jest.fn(() => ({then: (resolve: any) => resolve(successResult)}));
+
+    const {result} = renderHook(() => useLoadData(getThenableSuccess));
+    expect(result.current.isInProgress).toBe(true);
+    await waitFor(() => expect(result.current.isInProgress).toBe(false));
+    expect(result.current.result).toBe(successResult);
+  });
 });

--- a/hooks/useLoadData/useLoadData.ts
+++ b/hooks/useLoadData/useLoadData.ts
@@ -35,10 +35,7 @@ function unboxApiResponse<T>(arg: ApiResponse<T> | T): T {
   native promise (preferred) or whether it has a then method.
 */
 function isPromise<T>(promisable: Promisable<T>): promisable is Promise<T> {
-  return (
-    promisable instanceof Promise ||
-    (promisable && typeof promisable === 'object' && 'then' in promisable && typeof promisable.then === 'function')
-  );
+  return promisable && typeof promisable === 'object' && 'then' in promisable && typeof promisable.then === 'function';
 }
 
 export interface LoadDataConfig {

--- a/hooks/useLoadData/useLoadData.ts
+++ b/hooks/useLoadData/useLoadData.ts
@@ -1,5 +1,5 @@
 import {useEffect, useState, useMemo} from 'react';
-import {ApiResponse, RetryResponse, ApiResponseBase, OptionalDependency, DependencyBase} from '../../types';
+import {ApiResponse, RetryResponse, ApiResponseBase, OptionalDependency, DependencyBase, Promisable} from '../../types';
 
 import {FetchData, NotUndefined} from './types';
 
@@ -28,6 +28,17 @@ function unboxApiResponse<T>(arg: ApiResponse<T> | T): T {
   } else {
     return arg;
   }
+}
+
+/*
+  isPromise determines a promise by checking whether or not it is an instanceof 
+  native promise (preferred) or whether it has a then method.
+*/
+function isPromise<T>(promisable: Promisable<T>): promisable is Promise<T> {
+  return (
+    promisable instanceof Promise ||
+    (promisable && typeof promisable === 'object' && 'then' in promisable && typeof promisable.then === 'function')
+  );
 }
 
 export interface LoadDataConfig {
@@ -186,7 +197,8 @@ export function useLoadData<T extends NotUndefined, Deps extends any[]>(
     }
   }, [counter, localFetchWhenDepsChange]);
 
-  const nonPromiseResult = initialPromise.res instanceof Promise ? undefined : initialPromise.res;
+  const initialPromiseRes = initialPromise.res;
+  const nonPromiseResult = isPromise(initialPromiseRes) ? undefined : initialPromiseRes;
   const initialData = data || nonPromiseResult;
 
   // Initialize our pending data to one of three possible states:

--- a/hooks/useLoadData/useLoadData.ts
+++ b/hooks/useLoadData/useLoadData.ts
@@ -30,11 +30,11 @@ function unboxApiResponse<T>(arg: ApiResponse<T> | T): T {
   }
 }
 
-/*
-  isPromise determines a promise by checking whether or not it is an instanceof 
-  native promise (preferred) or whether it has a then method.
-*/
 function isPromise<T>(promisable: Promisable<T>): promisable is Promise<T> {
+  /*
+    simply checking promisable instanceof Promise is not sufficient. 
+    Certain environments to not use native promises
+  */
   return promisable && typeof promisable === 'object' && 'then' in promisable && typeof promisable.then === 'function';
 }
 
@@ -194,8 +194,7 @@ export function useLoadData<T extends NotUndefined, Deps extends any[]>(
     }
   }, [counter, localFetchWhenDepsChange]);
 
-  const initialPromiseRes = initialPromise.res;
-  const nonPromiseResult = isPromise(initialPromiseRes) ? undefined : initialPromiseRes;
+  const nonPromiseResult = isPromise(initialPromise.res) ? undefined : initialPromise.res;
   const initialData = data || nonPromiseResult;
 
   // Initialize our pending data to one of three possible states:

--- a/hooks/useLoadData/useLoadData.ts
+++ b/hooks/useLoadData/useLoadData.ts
@@ -32,8 +32,9 @@ function unboxApiResponse<T>(arg: ApiResponse<T> | T): T {
 
 function isPromise<T>(promisable: Promisable<T>): promisable is Promise<T> {
   /*
-    simply checking promisable instanceof Promise is not sufficient. 
-    Certain environments to not use native promises
+    Simply checking promisable instanceof Promise is not sufficient. 
+    Certain environments do not use native promises. Checking for promisable
+    to be thenable is a more comprehensive and conclusive test.
   */
   return promisable && typeof promisable === 'object' && 'then' in promisable && typeof promisable.then === 'function';
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optum/react-hooks",
-  "version": "1.0.4",
+  "version": "1.0.5-next.1",
   "description": "A reusable set of React hooks",
   "repository": "https://github.com/Optum/react-hooks",
   "license": "Apache 2.0",


### PR DESCRIPTION
## Proposed changes

Currently, `useLoadData` makes the assumption a promise is a _native promises_. Non-native promises lead to a bug where we immediately assign `loadedData.result` a promise without ever evaluating that promise. 

The fix is to go into further depth when checking initial promise.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

