### PR TITLE
Simplify/optimize map-reduce in useLoadData

### DIFF
--- a/hooks/useLoadData/useLoadData.ts
+++ b/hooks/useLoadData/useLoadData.ts
@@ -68,14 +68,12 @@ function correctOptionalDependencies<Deps extends any[]>(args?: readonly [...Dep
 }
 
 function checkArgsAreLoaded<Deps extends any[]>(args?: readonly [...Deps]) {
-  return (args || [])
-    .map((arg: unknown) => {
-      if (isApiResponseBase(arg)) {
-        return !(arg.isInProgress || arg.isError);
-      }
-      return true;
-    })
-    .reduce((prev, curr) => prev && curr, true);
+  return (args || []).every((arg: unknown) => {
+    if (isApiResponseBase(arg)) {
+      return !(arg.isInProgress || arg.isError);
+    }
+    return true;
+  });
 }
 
 function normalizeArgumentOverloads<T extends NotUndefined, Deps extends any[]>(
@@ -283,14 +281,12 @@ export function useLoadData<T extends NotUndefined, Deps extends any[]>(
     const correctedArgs = correctOptionalDependencies(fetchDataArgs);
     const argsAreLoaded = checkArgsAreLoaded(correctedArgs);
 
-    const argsHaveErrors = (correctedArgs || [])
-      .map((arg: unknown) => {
-        if (isApiResponseBase(arg)) {
-          return arg.isError;
-        }
-        return false;
-      })
-      .reduce((prev, curr) => prev || curr, false);
+    const argsHaveErrors = (correctedArgs || []).some((arg: unknown) => {
+      if (isApiResponseBase(arg)) {
+        return arg.isError;
+      }
+      return false;
+    });
 
     if (argsHaveErrors) {
       setPendingData({


### PR DESCRIPTION
## Proposed changes

I saw the usage of map-reduce in useLoadData, and I think that those can be simplified by using `Array.prototype.every` and `Array.prototype.some` instead.

In addition to the simplification, this should provide some time and space optimization.
- Time: `.some()` and `.every()` will terminate early (still O(n) though)
- Space: should also be reduced from O(n) to O(1) because they do not build a new array like `.map()` does

Fixes #41 


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
